### PR TITLE
fix tensor type byte warning

### DIFF
--- a/head/AM_Softmax.py
+++ b/head/AM_Softmax.py
@@ -25,7 +25,7 @@ class AM_Softmax(Module):
         cos_theta_m = cos_theta - self.margin
         index = torch.zeros_like(cos_theta)
         index.scatter_(1, labels.data.view(-1, 1), 1)
-        index = index.byte()
+        index = index.byte().bool()
         output = cos_theta * 1.0
         output[index] = cos_theta_m[index]
         output *= self.scale

--- a/head/AdaM_Softmax.py
+++ b/head/AdaM_Softmax.py
@@ -31,7 +31,7 @@ class Adam_Softmax(Module):
         cos_theta_m = cos_theta - margin
         index = torch.zeros_like(cos_theta)
         index.scatter_(1,labels.data.view(-1,1),1)
-        index = index.byte()
+        index = index.byte().bool()
         output = cos_theta * 1.0
         output[index] = cos_theta_m[index]
         output *= self.scale

--- a/head/ArcFace.py
+++ b/head/ArcFace.py
@@ -35,7 +35,7 @@ class ArcFace(Module):
         cos_theta_m = torch.where(cos_theta > self.min_cos_theta, cos_theta_m, cos_theta-self.margin_am)
         index = torch.zeros_like(cos_theta)
         index.scatter_(1, labels.data.view(-1, 1), 1)
-        index = index.byte()
+        index = index.byte().bool()
         output = cos_theta * 1.0
         output[index] = cos_theta_m[index]
         output *= self.scale

--- a/head/CircleLoss.py
+++ b/head/CircleLoss.py
@@ -31,10 +31,10 @@ class CircleLoss(Module):
         cos_theta = cos_theta.clamp(-1, 1)
         index_pos = torch.zeros_like(cos_theta)        
         index_pos.scatter_(1, labels.data.view(-1, 1), 1)
-        index_pos = index_pos.byte()
+        index_pos = index_pos.byte().bool()
         index_neg = torch.ones_like(cos_theta)        
         index_neg.scatter_(1, labels.data.view(-1, 1), 0)
-        index_neg = index_neg.byte()
+        index_neg = index_neg.byte().bool()
 
         alpha_p = torch.clamp_min(self.O_p - cos_theta.detach(), min=0.)
         alpha_n = torch.clamp_min(cos_theta.detach() - self.O_n, min=0.)

--- a/head/MagFace.py
+++ b/head/MagFace.py
@@ -46,7 +46,7 @@ class MagFace(Module):
         cos_theta_m = torch.where(cos_theta > min_cos_theta, cos_theta_m, cos_theta-self.margin_am)
         index = torch.zeros_like(cos_theta)
         index.scatter_(1, labels.data.view(-1, 1), 1)
-        index = index.byte()
+        index = index.byte().bool()
         output = cos_theta * 1.0
         output[index] = cos_theta_m[index]
         output *= self.scale


### PR DESCRIPTION
this commit fixes #35 

fix following error

"[W IndexingUtils.h:25] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead. (function expandTensors)"

no need to fix error by changing torch & torchvision version